### PR TITLE
Added readme for contributing to kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ stories, and anything that may be rometey useful to another operator or
 developer who works with or wants to learn to work with Kubernetes.
 
 ## Table of Contents
+* [Contributing to Kubernetes](./contributing-to-kubernetes/) - a collection of
+  common questions about the Kubernetes community. This is intended to be a
+  roadmap for the existing documentation. 
+* [go-client](./go-client/) - a collection of handy programs for building       
+  things on top of Kubernetes using the Go client.
 * [kind](./kind/) - [github.com/kubernetes-sigs/kind] relates resources,
   tutorials, etc.
-* [go-client](./go-client/) - a collection of handy programs for building
-  things on top of Kubernetes using the Go client.
 
 
 [github.com/kubernetes-sigs/kind]: https://github.com/kubernetes-sigs/kind

--- a/contributing-to-kubernetes/README.md
+++ b/contributing-to-kubernetes/README.md
@@ -1,0 +1,57 @@
+# Contributing to Kubernetes: A roadmap
+
+Hello :world:!
+
+Welcome to my roadmap of Kubernetes.
+This is purely acollection of useful links and some explanations of the
+existing and official
+[Kubernetes community documentation](https://github.com/kubernetes/community).
+
+## Organization
+
+Kuberentes has many types of groups and formats, but without a doubt you will
+see and hear a lot about Special Interest Groups (SIGs).
+Couple things to keep in mind, SIGs focus on an area or problem (i.e., how do
+we make Kubernetes easy to operate, how to develop a healthy community, or
+networking in Kubernetes), see the full list of
+[SIGs and Working Groups](https://github.com/kubernetes/community/blob/master/sig-list.md).
+
+SIGs usually have multiple subprojects.
+For example, two subprojects of SIG cluster lifecycle (a SIG who focuses on
+making Kubernetes easy to manage and operate) are
+[kubeadm](https://github.com/kubernetes/kubeadm) (a tool for creating
+Kubernetes clusters) and
+[cluster API](https://github.com/kubernetes-sigs/cluster-api) (a project
+building a cluster management API or an API).
+
+Please see
+[community governance](https://github.com/kubernetes/community#governance)
+for full details.
+
+## Finding a Place to Work
+
+If you are interested in contributing to Kubernetes then it is very likely that
+you want to join a SIG.
+To **join** a SIG, all you have to do is show up :smile:.
+
+There are a couple things you'll have to do to get set up with a SIG:
+1. Join their Slack channel. Head over to https://slack.k8s.io to join slack.
+2. Join their mailing list. Head over to
+  [SIGs and Working Groups](https://github.com/kubernetes/community/blob/master/sig-list.md)
+  look for the SIG you are interested in and look in their contact area for
+  their mailing list. Mailing lists are implemented via Google groups. Once you
+  join the appropiate Google group you will also get invitations for all of the
+  given SIG's meetings.
+3. Attend SIG meetings or catch up with their
+  [YouTubere cordings](https://www.youtube.com/channel/UCZ2bu0qutTOM0tHYa_jkIwg).
+
+However, this is only half the battle!
+In order to find something to work on you will have to be up to date with the
+work that is going on, participate in the discussions, do code reviews, triage
+existing issues, fix tests (check out https://testgrid.k8s.io/ :heart:).
+
+This is not glamurous work but it is very useful to the community at large.
+If you do it for long enough, things will make more sense.
+This is the way to become a reviewer and later on an approver, see
+[community membership](https://github.com/kubernetes/community/blob/master/community-membership.md#community-membership)
+for more details.


### PR DESCRIPTION
Why:
contributing to kubernetes can be both exiting and daunting.
The existing documentation is very thorough but extremely extensive.
This guide is supposed to be the roadmap for the official docs and
nothing more.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>